### PR TITLE
initial core library. converted from Vixen

### DIFF
--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -15,3 +15,71 @@
 #pragma once
 
 #include <ht_platform.h>
+#include <ht_string.h>
+#include <iostream>
+#include <iomanip>
+
+#ifdef HT_SYS_LINUX
+#include <cstdarg>
+#endif
+
+namespace Hatchit {
+
+    namespace Core {
+
+
+        /*! \brief Function implements variable formatted argument debug print
+        *
+        *
+        *  This debug utility function takes in a user format string and
+        *  a variable argument list, then prints the formatted string result
+        *  to the console
+        *  @param format The format string
+        *  @param argList the argument list used with format string
+        */
+        inline int VDebugPrintF(const char* format, va_list argList)
+        {
+            static char s_buffer[HT_BUFSIZE];
+            int written = -1;
+
+            #ifdef HT_SYS_WINDOWS
+                written = vsnprintf_s(s_buffer, HT_BUFSIZE, format, argList);
+            #else
+                written = vsnprintf(s_buffer, sizeof(s_buffer), format, argList);
+            #endif
+
+            #ifdef HT_SYS_WINDOWS
+                //Call Win32 debug output to pump message to
+                //Visual Studio console
+                OutputDebugString(s_buffer);
+            #endif
+
+            std::cerr << s_buffer;
+
+            return written;
+        }
+
+        /*! \brief Function takes a formatted string and arguments to print
+        *
+        *
+        *  This debug utility function takes in a user format string and
+        *  a variable argument list, then prints the formatted string result
+        *  to the console
+        *  @param format The format string
+        *  @param ... the argument list used with format string
+        */
+        inline int DebugPrintF(const char* format, ...)
+        {
+            va_list argList;
+            va_start(argList, format);
+
+            int written = VDebugPrintF(format, argList);
+
+            va_end(argList);
+
+            return written;
+        }
+
+    }
+
+}

--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -51,7 +51,7 @@ namespace Hatchit {
             #ifdef HT_SYS_WINDOWS
                 //Call Win32 debug output to pump message to
                 //Visual Studio console
-                OutputDebugString(s_buffer);
+                OutputDebugStringA(s_buffer);
             #endif
 
             std::cerr << s_buffer;

--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -23,6 +23,14 @@
 #include <cstdarg>
 #endif
 
+#ifndef HT_STRINGIFY
+#define HT_STRINGIFY(x) #x
+#endif
+
+#ifndef HT_SFY_
+#define HT_SFY_(x) HT_STRINGIFY(x)
+#endif
+
 namespace Hatchit {
 
     namespace Core {

--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -1,0 +1,17 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#pragma once
+
+#include <ht_platform.h>

--- a/include/ht_file.h
+++ b/include/ht_file.h
@@ -33,7 +33,7 @@ namespace Hatchit {
             virtual std::string Path(void)                                  override;
             virtual std::string BaseName(void)                              override;
             virtual void        Open(std::string path, FileMode mode)       override;
-            virtual bool        Seek(long offset, FileSeek mode)          override;
+            virtual bool        Seek(long offset, FileSeek mode)            override;
             virtual size_t      Read(BYTE* out, size_t len)                 override;
             virtual size_t      Write(BYTE* in, size_t len)                 override;
             virtual bool        Close(void)                                 override;
@@ -51,7 +51,7 @@ namespace Hatchit {
             size_t      m_size;
             FILE*       m_handle;
 
-        public:
+        private:
             static std::string GetExtension(const std::string& path, bool wd = true);
             static std::string GetName(const std::string& path, bool we = true);
         };

--- a/include/ht_file.h
+++ b/include/ht_file.h
@@ -1,0 +1,61 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#pragma once
+
+#include <ht_platform.h>
+#include <ht_file_interface.h>
+#include <ht_file_exception.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        class HT_API File : public IFile
+        {
+        public:
+            File(void);
+
+            ~File(void);
+
+            virtual std::string Name(void)                                  override;
+            virtual std::string Path(void)                                  override;
+            virtual std::string BaseName(void)                              override;
+            virtual void        Open(std::string path, FileMode mode)       override;
+            virtual bool        Seek(long offset, FileSeek mode)          override;
+            virtual size_t      Read(BYTE* out, size_t len)                 override;
+            virtual size_t      Write(BYTE* in, size_t len)                 override;
+            virtual bool        Close(void)                                 override;
+            virtual size_t      Tell(void)                                  override;
+            virtual size_t      SizeBytes(void)                             override;
+            virtual size_t      SizeKBytes(void)                            override;
+            virtual size_t      Position(void)                              override;
+            virtual FILE*       Handle(void)                                override;
+
+        private:
+            std::string m_path;
+            std::string m_name;
+            std::string m_baseName;
+            size_t      m_position;
+            size_t      m_size;
+            FILE*       m_handle;
+
+        public:
+            static std::string GetExtension(const std::string& path, bool wd = true);
+            static std::string GetName(const std::string& path, bool we = true);
+        };
+
+    }
+
+}

--- a/include/ht_file_exception.h
+++ b/include/ht_file_exception.h
@@ -29,13 +29,13 @@ namespace Hatchit {
 
             ~FileException(void);
 
-            virtual const char* what() const override;
+            virtual const char* what() const NOEXCEPT override;
 
         private:
             std::string m_errorString;
             std::string m_whatString;
         };
-    
+
     }
 
 }

--- a/include/ht_file_exception.h
+++ b/include/ht_file_exception.h
@@ -12,22 +12,30 @@
 **
 **/
 
+#pragma once
+
+#include <ht_platform.h>
 #include <ht_string.h>
-#include <ht_types.h>
+#include <exception>
 
 namespace Hatchit {
 
     namespace Core {
 
-        void str_replaceAll(std::string& input, const std::string& from, const std::string& to)
+        class HT_API FileException : public std::exception
         {
-            size_t pos = 0;
-            while ((pos = input.find(from, pos)) != std::string::npos) {
-                input.replace(pos, from.length(), to);
-                pos += to.length();
-            }
-        }
+        public:
+            FileException(std::string file, int error);
 
+            ~FileException(void);
+
+            virtual const char* what() const override;
+
+        private:
+            std::string m_errorString;
+            std::string m_whatString;
+        };
+    
     }
 
 }

--- a/include/ht_file_interface.h
+++ b/include/ht_file_interface.h
@@ -1,0 +1,65 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#pragma once
+
+#include <ht_platform.h>
+#include <ht_string.h>
+#include <ht_os.h>
+#include <ht_noncopy.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        enum class FileSeek
+        {
+            Current,
+            End,
+            Set
+        };
+
+        enum class FileMode
+        {
+            ReadText,
+            ReadBinary,
+            WriteText,
+            WriteBinary,
+            AppendText,
+            AppendBinary
+        };
+
+        class HT_API IFile : public INonCopy
+        {
+        public:
+            virtual ~IFile() { };
+
+            virtual std::string Name(void) = 0;
+            virtual std::string Path(void) = 0;
+            virtual std::string BaseName(void) = 0;
+            virtual void        Open(std::string path, FileMode mode) = 0;
+            virtual bool        Seek(long offset, FileSeek mode) = 0;
+            virtual bool        Close(void) = 0;
+            virtual size_t      Read(BYTE* out, size_t len) = 0;
+            virtual size_t      Write(BYTE* in, size_t len) = 0;
+            virtual size_t      Tell(void) = 0;
+            virtual size_t      SizeBytes(void) = 0;
+            virtual size_t      SizeKBytes(void) = 0;
+            virtual size_t      Position(void) = 0;
+            virtual FILE*       Handle() = 0;
+        };
+
+    }
+
+}

--- a/include/ht_ini_exception.h
+++ b/include/ht_ini_exception.h
@@ -12,32 +12,24 @@
 **
 **/
 
-#pragma once
-
 #include <ht_platform.h>
-
-/** \file ht_noncopy.h
-* Noncopy Interface
-
-* This file contains the interface definition
-* for noncopyable classes
-*/
+#include <ht_string.h>
+#include <exception>
 
 namespace Hatchit {
 
     namespace Core {
 
-        class HT_API INonCopy
+        class HT_API INIException : public std::exception
         {
-        protected:
-            INonCopy() { }
-            ~INonCopy() { }
+        public:
+            INIException(std::string name, int error);
+
+            const char* what() const NOEXCEPT override;
 
         private:
-            INonCopy(const INonCopy&);
-            const INonCopy& operator=(const INonCopy&);
+            std::string m_error;
         };
 
     }
-
 }

--- a/include/ht_inireader.h
+++ b/include/ht_inireader.h
@@ -1,0 +1,93 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_platform.h>
+#include <ht_file.h>
+#include <ht_ini_exception.h>
+#include <ini.h>
+#include <map>
+#include <algorithm>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        class HT_API INIReader
+        {
+        public:
+            INIReader(void);
+
+            void Load(File* file);
+
+            
+
+            template <typename T>
+            T GetValue(std::string section, std::string name, T default_val);
+
+        private:
+            int                                 m_error;
+            std::map<std::string, std::string>  m_values;
+
+            std::string Get(std::string section, std::string name);
+            static std::string      MakeKey(std::string section, std::string name);
+            static int              ValueHandler(void* user, const char* section, const char* name, const char* value);
+        };
+
+
+        template <>
+        inline bool INIReader::GetValue(std::string section, std::string name, bool default_val)
+        {
+            std::string value_str = Get(section, name);
+
+            std::transform(value_str.begin(), value_str.end(), value_str.begin(), ::tolower);
+            if (value_str == "true" || value_str == "yes" || value_str == "on" || value_str == "1")
+                return true;
+            else if (value_str == "false" || value_str == "no" || value_str == "off" || value_str == "0")
+                return false;
+            else
+                return default_val;
+        }
+
+        template <>
+        inline int INIReader::GetValue(std::string section, std::string name, int default_val)
+        {
+            std::string value_str = Get(section, name);
+
+            const char* value = value_str.c_str();
+
+            int _val = std::atoi(value);
+
+            return _val != 0 ? _val : default_val;
+        }
+
+        template <>
+        inline double INIReader::GetValue(std::string section, std::string name, double default_val)
+        {
+            std::string value_str = Get(section, name);
+
+            const char* value = value_str.c_str();
+
+            double _val = std::atof(value);
+
+            return _val != 0.0 ? _val : default_val;
+        }
+
+        template <>
+        inline float INIReader::GetValue(std::string section, std::string name, float default_val)
+        {
+            return static_cast<float>(INIReader::GetValue<double>(section, name, default_val));
+        }
+    }
+
+}

--- a/include/ht_inireader.h
+++ b/include/ht_inireader.h
@@ -30,7 +30,7 @@ namespace Hatchit {
 
             void Load(File* file);
 
-            
+            bool Empty();
 
             template <typename T>
             T GetValue(std::string section, std::string name, T default_val);
@@ -44,6 +44,16 @@ namespace Hatchit {
             static int              ValueHandler(void* user, const char* section, const char* name, const char* value);
         };
 
+        template <>
+        inline std::string INIReader::GetValue(std::string section, std::string name, std::string default_val)
+        {
+            std::string value_str = Get(section, name);
+
+            if (value_str.empty())
+                return default_val;
+            else
+                return value_str;
+        }
 
         template <>
         inline bool INIReader::GetValue(std::string section, std::string name, bool default_val)

--- a/include/ht_iniwriter.h
+++ b/include/ht_iniwriter.h
@@ -1,0 +1,81 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_platform.h>
+#include <ht_string.h>
+#include <ht_file.h>
+#include <map>
+#include <vector>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        class HT_API INIWriter
+        {
+            typedef std::vector<std::pair<std::string, std::string> > ValuePairList;
+        public:
+            INIWriter(void);
+
+            void Write(File* file);
+
+            template <typename T>
+            void SetValue(std::string section, std::string name, T value);
+
+        private:
+            std::map<std::string, ValuePairList> m_values;
+        };
+
+        template <>
+        inline void INIWriter::SetValue(std::string section, std::string name, int value)
+        {
+            ValuePairList& list = m_values[section];
+
+            std::string val = std::to_string(value);
+            
+            list.push_back(std::make_pair(name, val));
+        }
+
+        template <>
+        inline void INIWriter::SetValue(std::string section, std::string name, bool value)
+        {
+            ValuePairList& list = m_values[section];
+
+            std::string val = std::to_string(value);
+
+            list.push_back(std::make_pair(name, val));
+        }
+        
+        template <>
+        inline void INIWriter::SetValue(std::string section, std::string name, float value)
+        {
+            ValuePairList& list = m_values[section];
+
+            std::string val = std::to_string(value);
+
+            list.push_back(std::make_pair(name, val));
+        }
+
+        template <>
+        inline void INIWriter::SetValue(std::string section, std::string name, double value)
+        {
+            ValuePairList& list = m_values[section];
+
+            std::string val = std::to_string(value);
+
+            list.push_back(std::make_pair(name, val));
+        }
+    }
+
+}

--- a/include/ht_noncopy.h
+++ b/include/ht_noncopy.h
@@ -12,21 +12,24 @@
 **
 **/
 
-#include <ht_string.h>
-#include <ht_types.h>
+#pragma once
+
+#include <ht_platform.h>
 
 namespace Hatchit {
 
     namespace Core {
 
-        void str_replaceAll(std::string& input, const std::string& from, const std::string& to)
+        class HT_API INonCopy
         {
-            size_t pos = 0;
-            while ((pos = input.find(from, pos)) != std::string::npos) {
-                input.replace(pos, from.length(), to);
-                pos += to.length();
-            }
-        }
+        protected:
+            INonCopy() { }
+            ~INonCopy() { }
+
+        private:
+            INonCopy(const INonCopy&);
+            const INonCopy& operator=(const INonCopy&);
+        };
 
     }
 

--- a/include/ht_os.h
+++ b/include/ht_os.h
@@ -17,16 +17,51 @@
 #include <ht_platform.h>
 #include <ht_string.h>
 
+/** \file ht_os.h
+* Operating System Utilities
+
+* This file contains utility functions for operating system tasks,
+* and each function is defined to be cross platform.
+*/
+
 namespace Hatchit {
+
 
     namespace Core {
 
+		/*! \brief Function creates a directory on disk
+		*
+		*  Creates a directory on the file system with specified path
+		*  @param path directory path
+		*/
         HT_API void             os_mkdir(const std::string& path);
+
+		/*! \brief Function checks is specified path is a directory
+		*
+		*  Returns true or false is specified path is a directory
+		*  @param path directory path
+		*/
         HT_API bool             os_isdir(const std::string& path);
+
+		/*! \brief Function returns os standard path
+		*
+		*  Returns specified path with correct path delimeters
+		*  @param path the system path
+		*/
         HT_API std::string      os_path(const std::string& path);
+
+		/*! \brief Function returns the parent directory of a path
+		*
+		*  @param path system path
+		*  @param wt   should include trailing slash
+		*/
         HT_API std::string      os_dir(const std::string& path, bool wt = true);
+
+		/*! \brief Function returns the current executable directory
+		*
+		*/
         HT_API std::string      os_exec_dir();
 
     }
 
-}
+} 

--- a/include/ht_os.h
+++ b/include/ht_os.h
@@ -1,0 +1,32 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#pragma once
+
+#include <ht_platform.h>
+#include <ht_string.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        HT_API void             os_mkdir(const std::string& path);
+        HT_API bool             os_isdir(const std::string& path);
+        HT_API std::string      os_path(const std::string& path);
+        HT_API std::string      os_dir(const std::string& path, bool wt = true);
+        HT_API std::string      os_exec_dir();
+
+    }
+
+}

--- a/include/ht_platform.h
+++ b/include/ht_platform.h
@@ -37,7 +37,7 @@
 #endif
 
 /////////////////////////////////////////////////////////////
-// Defined portable API import/export macros
+// Define portable API import/export macros
 /////////////////////////////////////////////////////////////
 
 #if !defined(HT_STATIC)
@@ -71,3 +71,8 @@
     //static build doesn't need import/export macros
     #define HT_API
 #endif
+
+//////////////////////////////
+// BYTE typedef
+//////////////////////////////
+typedef unsigned char BYTE;

--- a/include/ht_platform.h
+++ b/include/ht_platform.h
@@ -72,6 +72,14 @@
     #define HT_API
 #endif
 
+#ifndef _MSC_VER
+#define NOEXCEPT noexcept
+#elif _MSC_VER >= 1900
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT 
+#endif
+
 //////////////////////////////
 // BYTE typedef
 //////////////////////////////

--- a/include/ht_singleton.h
+++ b/include/ht_singleton.h
@@ -1,0 +1,38 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_platform.h>
+#include <ht_noncopy.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        template <typename T>
+        class HT_API Singleton : private INonCopy
+        {
+        public:
+            static T& instance()
+            {
+                static T _instance;
+
+                return _instance;
+            }
+
+        protected:
+            explicit Singleton<T>() { }
+        };
+
+    }
+}

--- a/include/ht_string.h
+++ b/include/ht_string.h
@@ -18,6 +18,10 @@
 #include <sstream>
 #include <vector>
 
+#ifndef HT_BUFSIZE
+#define HT_BUFSIZE 1024
+#endif
+
 namespace Hatchit {
 
     namespace Core {

--- a/include/ht_string.h
+++ b/include/ht_string.h
@@ -1,0 +1,42 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+
+#include <ht_platform.h>
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace Hatchit {
+
+    namespace Core {
+
+
+        /*! \brief Function replaces occurences of character in string
+        *
+        *
+        *  This string utility function takes in a user string and replaces
+        *  all occurences of a specified character or string with another
+        *  @param input The string to modify
+        *  @param from  The character to replace
+        *  @param to    The character to replace with
+        */
+        HT_API
+        void str_replaceAll(std::string& input,
+                            const std::string& from,
+                            const std::string& to);
+
+    }
+
+}

--- a/include/ht_types.h
+++ b/include/ht_types.h
@@ -1,0 +1,16 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_platform.h>
+#include <cstdint>

--- a/include/ht_version.h
+++ b/include/ht_version.h
@@ -1,0 +1,3 @@
+#define HatchitEngine_VERSION_MAJOR 0
+#define HatchitEngine_VERSION_MINOR 1
+#define HatchitEngine_VERSION_BUILD 1

--- a/include/ht_version.h.in
+++ b/include/ht_version.h.in
@@ -1,0 +1,3 @@
+#define HatchitEngine_VERSION_MAJOR @HatchitEngine_VERSION_MAJOR@
+#define HatchitEngine_VERSION_MINOR @HatchitEngine_VERSION_MINOR@
+#define HatchitEngine_VERSION_BUILD @HatchitEngine_VERSION_BUILD@

--- a/source/ht_file.cpp
+++ b/source/ht_file.cpp
@@ -14,6 +14,10 @@
 
 #include <ht_file.h>
 
+#ifdef HT_SYS_LINUX
+#include <sys/stat.h>
+#endif
+
 namespace Hatchit {
 
     namespace Core {
@@ -187,7 +191,7 @@ namespace Hatchit {
                 //Need to grab size from stat struct in order to allow for
                 //files > 2GB in size
                 struct stat st;
-                stat(m_filePath.c_str(), &st);
+                stat(m_path.c_str(), &st);
                 m_size = st.st_size;
             #else
                 WIN32_FILE_ATTRIBUTE_DATA fad;

--- a/source/ht_file.cpp
+++ b/source/ht_file.cpp
@@ -1,0 +1,271 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_file.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        File::File(void)
+            : IFile()
+        {
+            m_position = 0;
+            m_size = 0;
+        }
+
+        File::~File(void)
+        {
+            Close();
+        }
+
+        void File::Open(std::string path, FileMode mode)
+        {
+            m_path = os_path(path);
+            m_name = GetName(m_path);
+            m_baseName = GetName(m_path, false);
+
+            switch (mode)
+            {
+                case FileMode::ReadBinary:
+                {
+                    #ifdef HT_SYS_WINDOWS
+                        fopen_s(&m_handle, m_path.c_str(), "rb");
+                    #else
+                        m_handle = fopen(m_path.c_str(), "rb");
+                    #endif
+                } break;
+
+                case FileMode::ReadText:
+                {
+                    #ifdef HT_SYS_WINDOWS
+                        fopen_s(&m_handle, m_path.c_str(), "r");
+                    #else
+                        m_handle = fopen(m_path.c_str(), "r");
+                    #endif
+                } break;
+
+                case FileMode::WriteBinary:
+                {
+                    #ifdef HT_SYS_WINDOWS
+                        fopen_s(&m_handle, m_path.c_str(), "wb");
+                    #else
+                        m_handle = fopen(m_path.c_str(), "wb");
+                    #endif
+                } break;
+
+                case FileMode::WriteText:
+                {
+                    #ifdef HT_SYS_WINDOWS
+                        fopen_s(&m_handle, m_path.c_str(), "w");
+                    #else
+                        m_handle = fopen(m_path.c_str(), "w");
+                    #endif
+                } break;
+
+                case FileMode::AppendBinary:
+                {
+                    #ifdef HT_SYS_WINDOWS
+                        fopen_s(&m_handle, m_path.c_str(), "ab");
+                    #else
+                        m_handle = fopen(m_path.c_str(), "ab");
+                    #endif
+                } break;
+
+                case FileMode::AppendText:
+                {
+                    #ifdef HT_SYS_WINDOWS
+                        fopen_s(&m_handle, m_path.c_str(), "a");
+                    #else
+                        m_handle = fopen(m_path.c_str(), "a");
+                    #endif
+                } break;
+
+                default:
+                    break;
+            }
+
+            if (!m_handle)
+                throw FileException(m_path, errno);
+
+        }
+
+        bool File::Close(void)
+        {
+            int ret = 0;
+            //Close file if handle is active
+            if (m_handle)
+            {
+                fclose(m_handle);
+                m_handle = nullptr;
+            }
+
+            return (ret <  0) ? false : true;
+        }
+
+        size_t File::Read(BYTE* out, size_t len)
+        {
+            size_t _len = 0;
+
+            _len = fread(out, sizeof(BYTE), len, m_handle);
+
+            int err = errno;
+            if (err > 0)
+                throw FileException(m_path, err);
+
+            return _len;
+        }
+
+        size_t File::Write(BYTE* in, size_t len)
+        {
+            size_t _len = 0;
+
+            _len = fwrite(in, sizeof(BYTE), len, m_handle);
+
+            int err = errno;
+            if (err > 0)
+                throw FileException(m_path, err);
+
+            return _len;
+        }
+
+        bool File::Seek(long pos, FileSeek mode)
+        {
+            switch (mode)
+            {
+                case FileSeek::Set:
+                {
+                    fseek(m_handle, pos, SEEK_SET);
+                } break;
+
+                case FileSeek::Current:
+                {
+                    fseek(m_handle, pos, SEEK_CUR);
+                } break;
+
+                case FileSeek::End:
+                {
+                    fseek(m_handle, pos, SEEK_END);
+                } break;
+            }
+
+            m_position = Tell();
+
+            int err = errno;
+            if (err > 0) {
+                throw FileException(m_path, err);
+                return false;
+            }
+
+            return true;
+        }
+
+        size_t File::Tell(void)
+        {
+            return ftell(m_handle);
+        }
+
+        size_t File::Position(void)
+        {
+            return m_position;
+        }
+
+        size_t File::SizeBytes(void)
+        {
+            #ifdef HT_SYS_LINUX
+                //Need to grab size from stat struct in order to allow for
+                //files > 2GB in size
+                struct stat st;
+                stat(m_filePath.c_str(), &st);
+                m_size = st.st_size;
+            #else
+                WIN32_FILE_ATTRIBUTE_DATA fad;
+                if (!GetFileAttributesExA(m_path.c_str(), GetFileExInfoStandard, &fad))
+                    return -1;
+
+                LARGE_INTEGER size;
+                size.HighPart = fad.nFileSizeHigh;
+                size.LowPart = fad.nFileSizeLow;
+
+                m_size = static_cast<size_t>(size.QuadPart);
+            #endif
+
+            return m_size;
+        }
+
+        size_t File::SizeKBytes(void)
+        {
+            return SizeBytes() / 1024;
+        }
+
+        std::string File::Name(void)
+        {
+            return m_name;
+        }
+
+        std::string File::Path(void)
+        {
+            return m_path;
+        }
+
+        std::string File::BaseName(void)
+        {
+            return m_baseName;
+        }
+
+        FILE* File::Handle(void)
+        {
+            return m_handle;
+        }
+
+        std::string File::GetExtension(const std::string& path, bool wd /* = true */)
+        {
+            std::string ext = "";
+            size_t pos = path.rfind(".");
+            if (pos != std::string::npos)
+            {
+                if (wd)
+                    ext = path.substr(pos);
+                else
+                    ext = path.substr(pos + 1);
+            }
+
+            return ext;
+        }
+
+        std::string File::GetName(const std::string& path, bool we /* = true */)
+        {
+            std::string name = "";
+            std::string _path = os_path(path);
+            size_t pos = 0;
+#ifdef HT_SYS_WINDOWS
+            pos = _path.find_last_of('\\');
+            if(pos != std::string::npos)
+                _path.erase(0, pos + 1);
+#else
+            pos = _path.find_last_of('/');
+            if (pos != std::string::npos)
+                _path.erase(0, pos + 1);
+#endif
+            if (!we)
+            {
+                size_t extPos = _path.find_last_of(".");
+                _path = _path.substr(0, extPos);
+            }
+
+            return _path;
+        }
+    }
+
+}

--- a/source/ht_file_exception.cpp
+++ b/source/ht_file_exception.cpp
@@ -14,6 +14,10 @@
 
 #include <ht_file_exception.h>
 
+#ifdef HT_SYS_LINUX
+#include <cstring>
+#endif
+
 namespace Hatchit {
 
     namespace Core {
@@ -36,7 +40,7 @@ namespace Hatchit {
 
         }
 
-        const char* FileException::what() const
+        const char* FileException::what() const NOEXCEPT
         {
             return m_whatString.c_str();
         }

--- a/source/ht_file_exception.cpp
+++ b/source/ht_file_exception.cpp
@@ -1,0 +1,46 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_file_exception.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        FileException::FileException(std::string file, int error)
+            : std::exception()
+        {
+#ifdef HT_SYS_WINDOWS
+            char errString[HT_BUFSIZE];
+            strerror_s(errString, HT_BUFSIZE, error);
+            m_errorString = errString;
+#else
+            m_errorString = strerror(error);
+#endif
+            m_whatString = "File Exception: @[" + file + "]--" + m_errorString;
+        }
+
+        FileException::~FileException()
+        {
+
+        }
+
+        const char* FileException::what() const
+        {
+            return m_whatString.c_str();
+        }
+
+    }
+
+}

--- a/source/ht_ini_exception.cpp
+++ b/source/ht_ini_exception.cpp
@@ -1,0 +1,42 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_ini_exception.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        INIException::INIException(std::string name, int error)
+        {
+            std::stringstream ss;
+            ss << "INI Exception: [" << name << "]";
+            if (error > 0)
+                ss << "--Parse error at line # " << error;
+            else if (error == -1)
+                ss << "--Could not open file for read";
+            else
+                ss << "--Memory allocation error";
+
+            m_error = ss.str();
+        }
+
+        const char* INIException::what() const NOEXCEPT
+        {
+            return m_error.c_str();
+        }
+
+    }
+
+}

--- a/source/ht_inireader.cpp
+++ b/source/ht_inireader.cpp
@@ -30,6 +30,11 @@ namespace Hatchit {
                 throw INIException(file->Name(), error);
         }
 
+        bool INIReader::Empty()
+        {
+            return m_values.empty();
+        }
+
         std::string INIReader::Get(std::string section, std::string name)
         {
             std::string key = MakeKey(section, name);

--- a/source/ht_inireader.cpp
+++ b/source/ht_inireader.cpp
@@ -1,0 +1,62 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_inireader.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        INIReader::INIReader(void)
+        {
+
+        }
+
+        void INIReader::Load(File* file)
+        {
+            int error = ini_parse_file(file->Handle(), ValueHandler, this);
+            if (error != 0)
+                throw INIException(file->Name(), error);
+        }
+
+        std::string INIReader::Get(std::string section, std::string name)
+        {
+            std::string key = MakeKey(section, name);
+
+            return m_values.count(key) ? m_values[key] : "";
+        }
+
+        std::string INIReader::MakeKey(std::string section, std::string name)
+        {
+            std::string key = section + "=" + name;
+
+            //transform key to all lower-case for case-insensitivity
+            std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+
+            return key;
+        }
+
+        int INIReader::ValueHandler(void* user, const char* section, const char* name, const char* value)
+        {
+            INIReader* reader = (INIReader*)user;
+            std::string key = MakeKey(section, name);
+            if (reader->m_values[key].size() > 0)
+                reader->m_values[key] += "\n";
+            reader->m_values[key] += value;
+
+            return 1;
+        }
+
+    }
+}

--- a/source/ht_iniwriter.cpp
+++ b/source/ht_iniwriter.cpp
@@ -1,0 +1,51 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_iniwriter.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        INIWriter::INIWriter()
+        {
+
+        }
+
+
+        void INIWriter::Write(File* file)
+        {
+            if (!file)
+                return;
+
+            for (auto& key : m_values)
+            {
+                //write section
+                std::string section = "[" + key.first + "]\n";
+                file->Write((BYTE*)section.c_str(), section.size());
+
+                ValuePairList _map = key.second;
+                for (size_t i = 0; i < _map.size(); i++)
+                {
+                    std::string name = _map[i].first;
+                    name += "=" + _map[i].second;
+                    name += "\n";
+
+                    file->Write((BYTE*)name.c_str(), name.size());
+                }
+            }
+        }
+    }
+
+}

--- a/source/ht_os.cpp
+++ b/source/ht_os.cpp
@@ -44,7 +44,7 @@ namespace Hatchit {
             //convert path
             std::string _path = os_path(path);
             #ifdef HT_SYS_WINDOWS
-                DWORD dwAttrib = GetFileAttributes(_path.c_str());
+                DWORD dwAttrib = GetFileAttributesA(_path.c_str());
                 return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
                         (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
             #elif defined(HT_SYS_LINUX)
@@ -79,7 +79,7 @@ namespace Hatchit {
             //remove trailing slash for now
             dir = path.substr(0, path.size() - 1);
 
-            uint32_t back_slash = 0;
+            size_t back_slash = 0;
             char c_slash;
             #ifdef HT_SYS_WINDOWS
                 c_slash = '\\';
@@ -99,7 +99,7 @@ namespace Hatchit {
         {
             #ifdef HT_SYS_WINDOWS
                 char path[MAX_PATH];
-                GetModuleFileName(NULL, path, MAX_PATH);
+                GetModuleFileNameA(NULL, path, MAX_PATH);
                 return os_dir(path);
             #else
                 char arg1[20];

--- a/source/ht_os.cpp
+++ b/source/ht_os.cpp
@@ -1,0 +1,116 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_os.h>
+#include <ht_types.h>
+
+#ifdef HT_SYS_WINDOWS
+#include <direct.h>
+#endif
+
+#ifdef HT_SYS_LINUX
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <linux/limits.h>
+#endif
+
+namespace Hatchit {
+
+    namespace Core {
+
+        void os_mkdir(const std::string& path)
+        {
+            #ifdef HT_SYS_WINDOWS
+                _mkdir(path.c_str());
+            #elif defined(HT_SYS_LINUX)
+                mkdir(path.c_str(), S_IRWXU);
+            #endif
+        }
+
+        bool os_isdir(const std::string& path)
+        {
+            //convert path
+            std::string _path = os_path(path);
+            #ifdef HT_SYS_WINDOWS
+                DWORD dwAttrib = GetFileAttributes(_path.c_str());
+                return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
+                        (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+            #elif defined(HT_SYS_LINUX)
+                struct stat info;
+                stat(_path.c_str(), &info);
+                return S_ISDIR(info.st_mode);
+            #endif
+
+            return false;
+        }
+
+        std::string os_path(const std::string& path)
+        {
+            std::string temp = path;
+
+            #ifdef HT_SYS_WINDOWS
+                str_replaceAll(temp, "/", "\\");
+            #else
+                str_replaceAll(temp, "\\", "/");
+            #endif
+
+            return temp;
+        }
+
+        std::string os_dir(const std::string& path, bool wt)
+        {
+            if(path.empty())
+                return "";
+
+            std::string dir = "";
+
+            //remove trailing slash for now
+            dir = path.substr(0, path.size() - 1);
+
+            uint32_t back_slash = 0;
+            char c_slash;
+            #ifdef HT_SYS_WINDOWS
+                c_slash = '\\';
+            #else
+                c_slash = '/';
+            #endif
+            back_slash = dir.find_last_of(c_slash);
+            if (back_slash != std::string::npos)
+                dir = dir.substr(0, back_slash);
+            if (wt)
+                dir += c_slash;
+
+            return dir;
+        }
+
+        std::string os_exec_dir()
+        {
+            #ifdef HT_SYS_WINDOWS
+                char path[MAX_PATH];
+                GetModuleFileName(NULL, path, MAX_PATH);
+                return os_dir(path);
+            #else
+                char arg1[20];
+                char exepath[PATH_MAX + 1] = {0};
+                sprintf( arg1, "/proc/%d/exe", getpid() );
+                readlink( arg1, exepath, 1024 );
+                return os_dir(exepath);
+            #endif
+
+            return "";
+        }
+    }
+
+}

--- a/source/ht_string.cpp
+++ b/source/ht_string.cpp
@@ -1,0 +1,33 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <ht_string.h>
+#include <ht_types.h>
+
+namespace Hatchit {
+
+    namespace Core {
+
+        void str_replaceAll(std::string& input, const std::string& from, const std::string& to)
+        {
+            uint32_t pos = 0;
+            while((pos = input.find(from, pos)) != std::string::npos) {
+                input.replace(pos, from.length(), to);
+                pos += to.length();
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
I've implemented most of the core library (the important bits) from Vixen into the new Hatchit Engine.

See HatchitGame, and HatchitTest for examples of usage.
