### PR TITLE
Replace raw C va_args with cppformat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "thirdparty/inih"]
 	path = thirdparty/inih
 	url = https://github.com/benhoyt/inih.git
+[submodule "thirdparty/cppformat"]
+	path = thirdparty/cppformat
+	url = https://github.com/cppformat/cppformat.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,9 @@ source_group("Headers" FILES ${HATCHIT_CORE_HEADERS})
 add_library(HatchitCore SHARED ${HATCHIT_CORE_HEADERS} ${HATCHIT_CORE_SOURCE})
 
 if(WIN32)
-    # We need to set this when building on Windows
+    # We need to define some things when building on Windows
     target_compile_definitions(HatchitCore PRIVATE HT_NONCLIENT_BUILD)
+    target_compile_definitions(HatchitCore PRIVATE FMT_EXPORT)
 endif()
 
 # Need to link some basic libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.7)
 
 set(BUILD_TEST FALSE CACHE BOOL "Build the Google test project")
 
@@ -33,9 +33,9 @@ file(GLOB HATCHIT_CORE_SOURCE
     "thirdparty/cppformat/cppformat/*.cc"
 )
 
-#C++ 11
+# C++ 11 and 64-bit on Linux
 if(UNIX)
-	set(CMAKE_CXX_FLAGS "-std=c++11 -g ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-std=c++11 -g -m64 ${CMAKE_CXX_FLAGS}")
 endif(UNIX)
 
 include_directories("include")
@@ -52,36 +52,36 @@ endif()
 
 # Need to link some basic libraries
 if(UNIX)
-	target_link_libraries(HatchitCore m)
+    target_link_libraries(HatchitCore m)
 endif(UNIX)
 
 set_property(TARGET HatchitCore PROPERTY FOLDER "lib")
 
 install(TARGETS HatchitCore
-		LIBRARY DESTINATION ${PROJECT_BINARY_DIR}
-		ARCHIVE DESTINATION ${PROJECT_BINARY_DIR})
+        LIBRARY DESTINATION ${PROJECT_BINARY_DIR}
+        ARCHIVE DESTINATION ${PROJECT_BINARY_DIR})
 
 # Test project
 if(BUILD_TEST)
-	project(HatchitCoreTest)
+    project(HatchitCoreTest)
 
-	find_package(GTest REQUIRED)
-	find_package(Threads REQUIRED)
+    find_package(GTest REQUIRED)
+    find_package(Threads REQUIRED)
 
-	file(GLOB TEST_SOURCE "test/*.cpp")
+    file(GLOB TEST_SOURCE "test/*.cpp")
 
-	include_directories(${GTEST_INCLUDE_DIRS})
+    include_directories(${GTEST_INCLUDE_DIRS})
 
-	add_executable(test_bin ${TEST_SOURCE})
-	target_link_libraries(test_bin ${GTEST_BOTH_LIBRARIES})
-	target_link_libraries(test_bin ${CMAKE_THREAD_LIBS_INIT})
+    add_executable(test_bin ${TEST_SOURCE})
+    target_link_libraries(test_bin ${GTEST_BOTH_LIBRARIES})
+    target_link_libraries(test_bin ${CMAKE_THREAD_LIBS_INIT})
 
     if(WIN32)
         target_link_libraries(test_bin HatchitCore)
     else()
-	   target_link_libraries(test_bin HatchitCore rt)
+        target_link_libraries(test_bin HatchitCore rt)
     endif()
 
-	enable_testing()
-	add_test(HatchitCore test_bin)
+    enable_testing()
+    add_test(HatchitCore test_bin)
 endif(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,13 @@ project(HatchitCore)
 if(WIN32)
     # We need to set this when building on Windows
     add_definitions(-DHT_NONCLIENT_BUILD)
-    set(HATCHIT_CORE_SYS_HEADERS "include/windows/*.h")
-    set(HATCHIT_CORE_SYS_SOURCE  "source/windows/*.cpp")
+    set(HATCHIT_CORE_SYS_HEADERS     "include/windows/*.h")
+    set(HATCHIT_CORE_SYS_HEADERS_DIR "include/windows")
+    set(HATCHIT_CORE_SYS_SOURCE      "source/windows/*.cpp")
 else()
-    set(HATCHIT_CORE_SYS_HEADERS "include/linux/*.h")
-    set(HATCHIT_CORE_SYS_SOURCE "source/linux/*.cpp")
+    set(HATCHIT_CORE_SYS_HEADERS     "include/linux/*.h")
+    set(HATCHIT_CORE_SYS_HEADERS_DIR "include/linux")
+    set(HATCHIT_CORE_SYS_SOURCE      "source/linux/*.cpp")
 endif()
 
 file(GLOB HATCHIT_CORE_HEADERS
@@ -19,6 +21,12 @@ file(GLOB HATCHIT_CORE_HEADERS
     ${HATCHIT_CORE_SYS_HEADERS}
     "thirdparty/inih/*.h"
     "thirdparty/cppformat/cppformat/*.h"
+)
+file(GLOB HATCHIT_CORE_HEADERS_DIRS
+    "include"
+    ${HATCHIT_CORE_SYS_HEADERS_DIR}
+    "thirdparty/inih"
+    "thirdparty/cppformat/cppformat"
 )
 file(GLOB HATCHIT_CORE_SOURCE
     "source/*.cpp"
@@ -34,6 +42,7 @@ endif(UNIX)
 
 include_directories("include")
 include_directories(SYSTEM)
+include_directories(${HATCHIT_CORE_HEADERS_DIRS})
 
 source_group("Headers" FILES ${HATCHIT_CORE_HEADERS})
 add_library(HatchitCore SHARED ${HATCHIT_CORE_HEADERS} ${HATCHIT_CORE_SOURCE})
@@ -58,19 +67,7 @@ if(BUILD_TEST)
 
 	file(GLOB TEST_SOURCE "test/*.cpp")
 
-    # General include directories
-    file(GLOB TEST_INCLUDE_DIRS "include" "thirdparty/inih" "thirdparty/cppformat/cppformat")
-
-    # System include directories
-    if(WIN32)
-        set(TEST_INCLUDE_SYS_DIRS "include/windows")
-    else()
-        set(TEST_INCLUDE_SYS_DIRS "include/linux")
-    endif()
-
 	include_directories(${GTEST_INCLUDE_DIRS})
-    include_directories(${TEST_INCLUDE_DIRS})
-    include_directories(${TEST_INCLUDE_SYS_DIRS})
 
 	add_executable(test_bin ${TEST_SOURCE})
 	target_link_libraries(test_bin ${GTEST_BOTH_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,31 @@
 cmake_minimum_required (VERSION 2.8.7)
 
-set(BUILD_TEST FALSE CACHE BOOL "Build the google test project")
+set(BUILD_TEST FALSE CACHE BOOL "Build the Google test project")
 
 project(HatchitCore)
 
-file(GLOB HATCHIT_CORE_HEADERS "include/*.h" "/include/linux/*.h" "thirdparty/inih/*.h")
-file(GLOB HATCHIT_CORE_SOURCE "source/*.cpp" "source/linux/*.cpp" "thirdparty/inih/*.c")
+if(WIN32)
+    # We need to set this when building on Windows
+    add_definitions(-DHT_NONCLIENT_BUILD)
+    set(HATCHIT_CORE_SYS_HEADERS "include/windows/*.h")
+    set(HATCHIT_CORE_SYS_SOURCE  "source/windows/*.cpp")
+else()
+    set(HATCHIT_CORE_SYS_HEADERS "include/linux/*.h")
+    set(HATCHIT_CORE_SYS_SOURCE "source/linux/*.cpp")
+endif()
+
+file(GLOB HATCHIT_CORE_HEADERS
+    "include/*.h"
+    ${HATCHIT_CORE_SYS_HEADERS}
+    "thirdparty/inih/*.h"
+    "thirdparty/cppformat/cppformat/*.h"
+)
+file(GLOB HATCHIT_CORE_SOURCE
+    "source/*.cpp"
+    ${HATCHIT_CORE_SYS_SOURCE}
+    "thirdparty/inih/*.c"
+    "thirdparty/cppformat/cppformat/*.cc"
+)
 
 #C++ 11
 if(UNIX)
@@ -38,13 +58,29 @@ if(BUILD_TEST)
 
 	file(GLOB TEST_SOURCE "test/*.cpp")
 
+    # General include directories
+    file(GLOB TEST_INCLUDE_DIRS "include" "thirdparty/inih" "thirdparty/cppformat/cppformat")
+
+    # System include directories
+    if(WIN32)
+        set(TEST_INCLUDE_SYS_DIRS "include/windows")
+    else()
+        set(TEST_INCLUDE_SYS_DIRS "include/linux")
+    endif()
+
 	include_directories(${GTEST_INCLUDE_DIRS})
-	include_directories("include" "include/linux" "thirdparty/inih")
+    include_directories(${TEST_INCLUDE_DIRS})
+    include_directories(${TEST_INCLUDE_SYS_DIRS})
 
 	add_executable(test_bin ${TEST_SOURCE})
 	target_link_libraries(test_bin ${GTEST_BOTH_LIBRARIES})
 	target_link_libraries(test_bin ${CMAKE_THREAD_LIBS_INIT})
-	target_link_libraries(test_bin HatchitCore rt)
+
+    if(WIN32)
+        target_link_libraries(test_bin HatchitCore)
+    else()
+	   target_link_libraries(test_bin HatchitCore rt)
+    endif()
 
 	enable_testing()
 	add_test(HatchitCore test_bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ set(BUILD_TEST FALSE CACHE BOOL "Build the Google test project")
 project(HatchitCore)
 
 if(WIN32)
-    # We need to set this when building on Windows
-    add_definitions(-DHT_NONCLIENT_BUILD)
     set(HATCHIT_CORE_SYS_HEADERS     "include/windows/*.h")
     set(HATCHIT_CORE_SYS_HEADERS_DIR "include/windows")
     set(HATCHIT_CORE_SYS_SOURCE      "source/windows/*.cpp")
@@ -47,7 +45,12 @@ include_directories(${HATCHIT_CORE_HEADERS_DIRS})
 source_group("Headers" FILES ${HATCHIT_CORE_HEADERS})
 add_library(HatchitCore SHARED ${HATCHIT_CORE_HEADERS} ${HATCHIT_CORE_SOURCE})
 
-#Need to link some basic libraries
+if(WIN32)
+    # We need to set this when building on Windows
+    target_compile_definitions(HatchitCore PRIVATE HT_NONCLIENT_BUILD)
+endif()
+
+# Need to link some basic libraries
 if(UNIX)
 	target_link_libraries(HatchitCore m)
 endif(UNIX)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Core Utilities library for Hatchit 3D Game Engine
 
 [![Build Status](https://travis-ci.org/thirddegree/HatchitCore.svg?branch=master)](https://travis-ci.org/thirddegree/HatchitCore)
 
-### Build instructions
+## Build instructions
 
-Building is simple. You just need CMake and a C++ compiler
+### Linux
 
-On Linux it's as simple as
+Simply install CMake and a C++ compiler. Then follow these commands:
 
 ```
 mkdir build
@@ -17,10 +17,13 @@ cmake ..
 make
 ```
 
-On Windows you'll probably want to run the CMake GUI to make a Visual Studio
-project
+### Windows
 
-### Building tests
+On Window's you'll just need CMake and a C++ compiler as well. However,
+when selecting the generator in CMake, make sure to use the 64-bit target!
+(E.g. "Visual Studio 14 2015 Win64")
+
+## Building tests
 
 Building tests works best on Linux. Travis CI is used to automate tests whenever
 you push to the repo.

--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -18,6 +18,7 @@
 #include <ht_string.h>
 #include <iostream>
 #include <iomanip>
+#include <format.h>
 
 #ifdef HT_SYS_LINUX
 #include <cstdarg>

--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -20,10 +20,6 @@
 #include <iomanip>
 #include <format.h>
 
-#ifdef HT_SYS_LINUX
-#include <cstdarg>
-#endif
-
 #ifndef HT_STRINGIFY
 #define HT_STRINGIFY(x) #x
 #endif
@@ -63,56 +59,40 @@ namespace Hatchit {
     namespace Core {
 
 
-        /*! \brief Function implements variable formatted argument debug print
+        /*! \brief Function takes a formatted string and arguments to format into a string.
         *
         *
         *  This debug utility function takes in a user format string and
         *  a variable argument list, then prints the formatted string result
-        *  to the console
-        *  @param format The format string
-        *  @param argList the argument list used with format string
+        *  to the console.
+        *  @param format The format string.
+        *  @param args The argument list used with format string.
         */
-        inline int VDebugPrintF(const char* format, va_list argList)
+        template<class ... Args> inline std::string DebugSprintF(const char* format, const Args& ... args)
         {
-            static char s_buffer[HT_BUFSIZE];
-            int written = -1;
-
-            #ifdef HT_SYS_WINDOWS
-                written = vsnprintf_s(s_buffer, HT_BUFSIZE, format, argList);
-            #else
-                written = vsnprintf(s_buffer, sizeof(s_buffer), format, argList);
-            #endif
-
-            #ifdef HT_SYS_WINDOWS
-                //Call Win32 debug output to pump message to
-                //Visual Studio console
-                OutputDebugStringA(s_buffer);
-            #endif
-
-            std::cerr << s_buffer;
-
-            return written;
+            return fmt::sprintf( format, args ... );
         }
 
-        /*! \brief Function takes a formatted string and arguments to print
+        /*! \brief Function takes a formatted string and arguments to print.
         *
         *
         *  This debug utility function takes in a user format string and
         *  a variable argument list, then prints the formatted string result
-        *  to the console
-        *  @param format The format string
-        *  @param ... the argument list used with format string
+        *  to the console.
+        *  @param format The format string.
+        *  @param args The argument list used with format string.
         */
-        inline int DebugPrintF(const char* format, ...)
+        template<class ... Args> inline int DebugPrintF(const char* format, const Args& ... args)
         {
-            va_list argList;
-            va_start(argList, format);
+            std::string message = fmt::sprintf( format, args ... );
 
-            int written = VDebugPrintF(format, argList);
+            #if defined(HT_SYS_WINDOWS)
+                OutputDebugStringA( message.c_str() );
+            #endif
 
-            va_end(argList);
+            std::cerr << message.c_str();
 
-            return written;
+            return static_cast<int>(message.length());
         }
 
     }

--- a/include/ht_platform.h
+++ b/include/ht_platform.h
@@ -47,12 +47,10 @@
             #ifndef HT_API
             #define HT_API __declspec(dllexport)
             #endif
-            #define FMT_EXPORT
         #else
             #ifndef HT_API
             #define HT_API __declspec(dllimport)
             #endif
-            #define FMT_SHARED
         #endif
 
         //Visual C++ compiler warning C4251 disable

--- a/include/ht_platform.h
+++ b/include/ht_platform.h
@@ -47,16 +47,18 @@
             #ifndef HT_API
             #define HT_API __declspec(dllexport)
             #endif
+            #define FMT_EXPORT
         #else
             #ifndef HT_API
             #define HT_API __declspec(dllimport)
             #endif
+            #define FMT_SHARED
         #endif
 
         //Visual C++ compiler warning C4251 disable
         #ifdef _MSC_VER
         #pragma warning(disable : 4251)
-		#pragma warning(disable : 4275)
+        #pragma warning(disable : 4275)
         #endif
 
     #else //Linux and MAC OSX

--- a/test/FormatTest.cpp
+++ b/test/FormatTest.cpp
@@ -1,0 +1,24 @@
+/**
+**    Hatchit Engine
+**    Copyright(c) 2015 Third-Degree
+**
+**    GNU Lesser General Public License
+**    This file may be used under the terms of the GNU Lesser
+**    General Public License version 3 as published by the Free
+**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+**    in the packaging of this file. Please review the following information
+**    to ensure the GNU Lesser General Public License requirements
+**    will be met: https://www.gnu.org/licenses/lgpl.html
+**
+**/
+
+#include <gtest/gtest.h>
+#include <ht_debug.h>
+
+TEST(FormatTest, MemoryPrint)
+{
+}
+
+TEST(FormatTest, ConsolePrint)
+{
+}

--- a/test/FormatTest.cpp
+++ b/test/FormatTest.cpp
@@ -13,12 +13,28 @@
 **/
 
 #include <gtest/gtest.h>
+#include <ht_platform.h>
 #include <ht_debug.h>
+
+using namespace Hatchit;
+using namespace Hatchit::Core;
 
 TEST(FormatTest, MemoryPrint)
 {
+    const char* abra = "abra";
+    std::string cad = "cad";
+    int         number = 42;
+    const char* emoji = "B)";
+
+    std::string formatted = DebugSprintF("%s%s%s %i %s", abra, cad, abra, number, emoji);
+
+    EXPECT_STREQ("abracadabra 42 B)", formatted.c_str());
 }
 
 TEST(FormatTest, ConsolePrint)
 {
+    float num1 = 3.14f;
+    float num2 = 4.13f;
+
+    DebugPrintF("%.2f * %.2f = %.4f\n", num1, num2, num1 * num2);
 }


### PR DESCRIPTION
cppformat is much safer due to the use of variadic templates. In addition to modifying DebugPrintF, I also added in DebugSprintF which will be useful when we get around to adding a visual debug layer.

I also added in Windows support for CMake (tested with 3.5.0).

I have tested my changes with both Visual Studio 2015 (64-bit Win10) and GCC 5.3.0 (Ubuntu 14.04), and the library compiles and the test project compiles and all tests pass.
