### PR TITLE
Add 'const' qualifier to std::hash overload for Guid

### DIFF
--- a/include/ht_guid.h
+++ b/include/ht_guid.h
@@ -124,7 +124,7 @@ namespace std {
      */
     template<> struct hash<Hatchit::Core::Guid>
     {
-        inline size_t operator()(const Hatchit::Core::Guid& guid)
+        inline size_t operator()(const Hatchit::Core::Guid& guid) const
         {
             return guid.Hash();
         }


### PR DESCRIPTION
This is necessary to be able to use Guid as a key in associative STL containers.
