### PR TITLE
Improve JSON extraction

### DIFF
--- a/include/ht_guid.h
+++ b/include/ht_guid.h
@@ -16,6 +16,7 @@
 
 #include <ht_platform.h>
 #include <stdint.h>
+#include <memory>   // For std::shared_ptr
 #include <string>
 
 namespace Hatchit {
@@ -31,8 +32,15 @@ namespace Hatchit {
         class HT_API Guid
         {
             uint8_t m_uuid[16];
+            uint64_t m_hashCode;
+            std::string m_originalString;
 
         public:
+            /**
+             * \brief The empty Guid.
+             */
+            static const Guid Empty;
+
             /**
              * \brief Creates a new Guid.
              */
@@ -58,11 +66,25 @@ namespace Hatchit {
             ~Guid();
 
             /**
-             * \brief Hashes this Guid.
+             * \brief Gets this Guid's hash code.
              *
              * Provides a 64-bit unsigned integer hash representation of this Guid.
              */
-            uint64_t Hash() const;
+            uint64_t GetHashCode() const;
+
+            /**
+             * \brief Gets this Guid's original string, if there is one.
+             *
+             * \return The original string, if it exists.
+             */
+            std::string GetOriginalString() const;
+
+            /**
+             * \brief Checks to see if this Guid is originally from a string.
+             *
+             * \return True if this Guid is based off of a string, false if not.
+             */
+            bool IsFromString() const;
 
             /**
              * \brief Gets the textual representation of this Guid.
@@ -102,6 +124,14 @@ namespace Hatchit {
 
         public:
             /**
+             * \brief Creates a Guid from a string by hashing the string.
+             *
+             * \param text The text to create a Guid from.
+             * \return The Guid based off of the given text.
+             */
+            static Guid FromString(const std::string& text);
+
+            /**
             * \brief Attempts to parse a Guid from its textual representation.
             *
             * \param text The text to parse.
@@ -126,7 +156,7 @@ namespace std {
     {
         inline size_t operator()(const Hatchit::Core::Guid& guid) const
         {
-            return guid.Hash();
+            return guid.GetHashCode();
         }
     };
 

--- a/include/ht_jsonhelper.h
+++ b/include/ht_jsonhelper.h
@@ -29,12 +29,12 @@ namespace Hatchit {
          */
         using JSON = nlohmann::json;
 
-#if defined(_DEBUG) || defined(DEBUG)
-
         /**
          * \brief The verification function used to validate JSON types.
          */
         using JsonVerifyFunc = bool(JSON::*)() const;
+
+#if defined(_DEBUG) || defined(DEBUG)
 
         /**
          * \brief Attempts to extract a value from a JSON object.
@@ -61,6 +61,34 @@ namespace Hatchit {
             return true;
         }
 
+#else
+
+        /**
+         * \brief Attempts to extract a value from a JSON object.
+         *
+         * \param json The JSON object.
+         * \param verify The JSON type verification function.
+         * \param name The name of the value to retrieve.
+         * \param out The output variable.
+         * \return True if the extraction was successful, false if not.
+         */
+        template<typename T>
+        static inline bool _JsonExtractValue(const JSON& json, JsonVerifyFunc verify, const std::string& name, T& out)
+        {
+#   if defined(HT_DISABLE_JSON_CHECKS)
+            out = json[name].get<T>();
+            return true;
+#   else
+            auto  search = json.find(name);
+            auto& object = *search;
+
+            out = object.get<T>();
+            return (object.*verify)();
+#   endif
+        }
+
+#endif
+
         /**
          * \brief Attempts to extract a string from a JSON object.
          *
@@ -69,7 +97,7 @@ namespace Hatchit {
          * \param out The output string.
          * \return True if the extraction was successful, false if not.
          */
-        #define JsonExtractString(json, name, out) _JsonExtractValue<std::string>(json, &JSON::is_string, name, out)
+        #define JsonExtractString(json, name, out) Hatchit::Core::_JsonExtractValue<std::string>(json, &JSON::is_string, name, out)
 
         /**
          * \brief Attempts to extract a double from a JSON object.
@@ -79,7 +107,7 @@ namespace Hatchit {
          * \param out The output string.
          * \return True if the extraction was successful, false if not.
          */
-        #define JsonExtractDouble(json, name, out) _JsonExtractValue<double>(json, &JSON::is_number_float, name, out)
+        #define JsonExtractDouble(json, name, out) Hatchit::Core::_JsonExtractValue<double>(json, &JSON::is_number_float, name, out)
 
         /**
          * \brief Attempts to extract a float from a JSON object.
@@ -89,7 +117,7 @@ namespace Hatchit {
          * \param out The output string.
          * \return True if the extraction was successful, false if not.
          */
-        #define JsonExtractBool(json, name, out) _JsonExtractValue<bool>(json, &JSON::is_boolean, name, out)
+        #define JsonExtractBool(json, name, out) Hatchit::Core::_JsonExtractValue<bool>(json, &JSON::is_boolean, name, out)
 
         /**
          * \brief Attempts to extract an int64 from a JSON object.
@@ -99,7 +127,7 @@ namespace Hatchit {
          * \param out The output string.
          * \return True if the extraction was successful, false if not.
          */
-        #define JsonExtractInt64(json, name, out) _JsonExtractValue<int64_t>(json, &JSON::is_number_integer, name, out)
+        #define JsonExtractInt64(json, name, out) Hatchit::Core::_JsonExtractValue<int64_t>(json, &JSON::is_number_integer, name, out)
 
         /**
          * \brief Attempts to extract a uint64 from a JSON object.
@@ -109,7 +137,7 @@ namespace Hatchit {
          * \param out The output string.
          * \return True if the extraction was successful, false if not.
          */
-        #define JsonExtractUint64(json, name, out) _JsonExtractValue<uint64_t>(json, &JSON::is_number_unsigned, name, out)
+        #define JsonExtractUint64(json, name, out) Hatchit::Core::_JsonExtractValue<uint64_t>(json, &JSON::is_number_unsigned, name, out)
 
         /**
          * \brief Attempts to extract a Guid from a JSON object.
@@ -119,64 +147,12 @@ namespace Hatchit {
          * \param out The output Guid.
          * \return True if the extraction was successful, false if not.
          */
-        static __forceinline bool JsonExtractGuid(const JSON& json, const std::string& name, Guid& out)
+        static __forceinline bool _JsonExtractGuid(const JSON& json, const std::string& name, Guid& out)
         {
             std::string guidText;
             return JsonExtractString(json, name, guidText) && Guid::Parse(guidText, out);
         }
 
-#else
-
-        /**
-         * \brief Attempts to extract a string from a JSON object.
-         *
-         * \param json The JSON object.
-         * \param name The name of the string to retrieve.
-         * \param out The output string.
-         * \return True if the extraction was successful, false if not.
-         */
-        #define JsonExtractString(json, name, out) out = json[name].get<std::string>()
-        
-        /**
-         * \brief Attempts to extract a double from a JSON object.
-         *
-         * \param json The JSON object.
-         * \param name The name of the double to retrieve.
-         * \param out The output string.
-         * \return True if the extraction was successful, false if not.
-         */
-        #define JsonExtractDouble(json, name, out) out = json[name]
-        
-        /**
-         * \brief Attempts to extract a float from a JSON object.
-         *
-         * \param json The JSON object.
-         * \param name The name of the float to retrieve.
-         * \param out The output string.
-         * \return True if the extraction was successful, false if not.
-         */
-        #define JsonExtractBool(json, name, out) out = json[name]
-        
-        /**
-         * \brief Attempts to extract an int64 from a JSON object.
-         *
-         * \param json The JSON object.
-         * \param name The name of the int64 to retrieve.
-         * \param out The output string.
-         * \return True if the extraction was successful, false if not.
-         */
-        #define JsonExtractInt64(json, name, out) out = json[name]
-        
-        /**
-         * \brief Attempts to extract a uint64 from a JSON object.
-         *
-         * \param json The JSON object.
-         * \param name The name of the uint64 to retrieve.
-         * \param out The output string.
-         * \return True if the extraction was successful, false if not.
-         */
-        #define JsonExtractUint64(json, name, out) out = json[name]
-
         /**
          * \brief Attempts to extract a Guid from a JSON object.
          *
@@ -185,15 +161,7 @@ namespace Hatchit {
          * \param out The output Guid.
          * \return True if the extraction was successful, false if not.
          */
-        static __forceinline bool JsonExtractGuid(const JSON& json, const std::string& name, Guid& out)
-        {
-            std::string guidText;
-            JsonExtractString(json, name, guidText);
-            return Guid::Parse(guidText, out);
-        }
-
-#endif
-
+        #define JsonExtractGuid(json, name, out) Hatchit::Core::_JsonExtractGuid(json, name, out)
     }
 
 }

--- a/include/ht_jsonhelper.h
+++ b/include/ht_jsonhelper.h
@@ -20,6 +20,9 @@
 #  include <ht_debug.h>
 #endif
 
+// Uncomment the following line to disable JSON type checking in release mode
+// #define HT_DISABLE_JSON_CHECKS
+
 namespace Hatchit {
 
     namespace Core {
@@ -117,6 +120,16 @@ namespace Hatchit {
          * \param out The output string.
          * \return True if the extraction was successful, false if not.
          */
+        #define JsonExtractFloat(json, name, out) Hatchit::Core::_JsonExtractValue<float>(json, &JSON::is_number_float, name, out)
+
+        /**
+         * \brief Attempts to extract a float from a JSON object.
+         *
+         * \param json The JSON object.
+         * \param name The name of the float to retrieve.
+         * \param out The output string.
+         * \return True if the extraction was successful, false if not.
+         */
         #define JsonExtractBool(json, name, out) Hatchit::Core::_JsonExtractValue<bool>(json, &JSON::is_boolean, name, out)
 
         /**
@@ -138,6 +151,26 @@ namespace Hatchit {
          * \return True if the extraction was successful, false if not.
          */
         #define JsonExtractUint64(json, name, out) Hatchit::Core::_JsonExtractValue<uint64_t>(json, &JSON::is_number_unsigned, name, out)
+
+        /**
+         * \brief Attempts to extract an int32 from a JSON object.
+         *
+         * \param json The JSON object.
+         * \param name The name of the int32 to retrieve.
+         * \param out The output string.
+         * \return True if the extraction was successful, false if not.
+         */
+        #define JsonExtractInt32(json, name, out) Hatchit::Core::_JsonExtractValue<int32_t>(json, &JSON::is_number_integer, name, out)
+
+        /**
+         * \brief Attempts to extract a uint32 from a JSON object.
+         *
+         * \param json The JSON object.
+         * \param name The name of the uint32 to retrieve.
+         * \param out The output string.
+         * \return True if the extraction was successful, false if not.
+         */
+        #define JsonExtractUint32(json, name, out) Hatchit::Core::_JsonExtractValue<uint32_t>(json, &JSON::is_number_unsigned, name, out)
 
         /**
          * \brief Attempts to extract a Guid from a JSON object.

--- a/source/ht_guid.cpp
+++ b/source/ht_guid.cpp
@@ -47,14 +47,67 @@ namespace Hatchit {
         GuidHelper GuidHelper::s_Instance;
 
         /**
+         * \brief Performs an FNV-1a hash on the given buffer.
+         *
+         * \param buffer The buffer to hash.
+         * \param bufferLen The buffer's length.
+         * \return The hash.
+         */
+        static uint64_t GetFnv1aHash(const void* buffer, uint64_t bufferLen)
+        {
+            // This is adapted from the 64-bit version of the FNV-1a hashing algorithm
+            // Source:  http://www.isthe.com/chongo/tech/comp/fnv/
+            // License: Public Domain
+
+            uint64_t hash = 0;
+            const uint8_t* byteBuffer = static_cast<const uint8_t*>(buffer);
+
+            for (uint64_t index = 0; index < bufferLen; ++index)
+            {
+                hash ^= static_cast<uint64_t>(byteBuffer[index]);
+
+                // The algorithm differs on the next part, so if we're compiling using
+                // GCC, then let's just use their optimization
+#if defined(__GNUC__)
+                hash += (hash << 1) + (hash << 4) + (hash << 5) +
+                        (hash << 7) + (hash << 8) + (hash << 40);
+#else
+                hash *= 0x100000001b3ULL;
+#endif
+            }
+
+            return hash;
+        }
+
+        /**
+         * \brief Creates an empty Guid.
+         *
+         * \return An empty Guid.
+         */
+        static Guid CreateEmptyGuid()
+        {
+            Guid a, b;
+            b = std::move(a);
+            return a;
+        }
+
+        // Declare the empty Guid
+        const Guid Guid::Empty = CreateEmptyGuid();
+
+        /**
          * \brief Creates a new Guid.
          */
         Guid::Guid()
+            : m_hashCode(0)
         {
+            // Generate the GUID bytes
             for (int index = 0; index < 16; ++index)
             {
                 m_uuid[index] = GuidHelper::GenerateByte();
             }
+
+            // Get the hash code
+            m_hashCode = GetFnv1aHash(m_uuid, 16);
         }
 
         /**
@@ -89,33 +142,62 @@ namespace Hatchit {
         }
 
         /**
+         * \brief Creates a Guid from a string by hashing the string.
+         *
+         * \param text The text to create a Guid from.
+         * \return The Guid based off of the given text.
+         */
+        Guid Guid::FromString(const std::string& text)
+        {
+            // If the text is empty, then return an empty Guid
+            if (text.empty())
+            {
+                return Guid::Empty;
+            }
+
+            // To do this, we'll hash the first half and the second half of the string
+            // and then copy the bytes over (will be 16 total bytes)
+            size_t half = text.length() / 2;
+            uint64_t firstHash = GetFnv1aHash(text.c_str(), half);
+            uint64_t secondHash = GetFnv1aHash(text.c_str() + half, text.length() - half);
+
+            Guid guid;
+            memcpy(guid.m_uuid, &firstHash, 8);
+            memcpy(guid.m_uuid + 8, &secondHash, 8);
+            guid.m_hashCode = GetFnv1aHash(guid.m_uuid, 16);
+            guid.m_originalString = text;
+
+            return guid;
+        }
+
+        /**
          * \brief Hashes this Guid.
          *
          * Provides a 64-bit unsigned integer hash representation of this Guid.
          */
-        uint64_t Guid::Hash() const
+        uint64_t Guid::GetHashCode() const
         {
-            // This is adapted from the 64-bit version of the FNV-1a hashing algorithm
-            // Source:  http://www.isthe.com/chongo/tech/comp/fnv/
-            // License: Public Domain
+            return m_hashCode;
+        }
+        
+        /**
+         * \brief Gets this Guid's original string, if there is one.
+         *
+         * \return The original string, if it exists.
+         */
+        std::string Guid::GetOriginalString() const
+        {
+            return m_originalString;
+        }
 
-            uint64_t hash = 0;
-
-            for (int index = 0; index < 16; ++index)
-            {
-                hash ^= static_cast<uint64_t>(m_uuid[index]);
-
-                // The algorithm differs on the next part, so if we're compiling using
-                // GCC, then let's just use their optimization
-#if defined(__GNUC__)
-                hash += (hash << 1) + (hash << 4) + (hash << 5) +
-                        (hash << 7) + (hash << 8) + (hash << 40);
-#else
-                hash *= 0x100000001b3ULL;
-#endif
-            }
-
-            return hash;
+        /**
+         * \brief Checks to see if this Guid is originally from a string.
+         *
+         * \return True if this Guid is based off of a string, false if not.
+         */
+        bool Guid::IsFromString() const
+        {
+            return !m_originalString.empty();
         }
 
         /**
@@ -244,14 +326,7 @@ namespace Hatchit {
          */
         bool Guid::operator==(const Guid& other) const
         {
-            for (int index = 0; index < 16; ++index)
-            {
-                if (m_uuid[index] != other.m_uuid[index])
-                {
-                    return false;
-                }
-            }
-            return true;
+            return m_hashCode == other.m_hashCode;
         }
 
         /**
@@ -261,7 +336,7 @@ namespace Hatchit {
          */
         bool Guid::operator!=(const Guid& other) const
         {
-            return !(*this == other);
+            return m_hashCode != other.m_hashCode;
         }
 
         /**
@@ -271,10 +346,18 @@ namespace Hatchit {
          */
         Guid& Guid::operator=(const Guid& other)
         {
+            // Copy GUID bytes
             for (int index = 0; index < 16; ++index)
             {
                 m_uuid[index] = other.m_uuid[index];
             }
+
+            // Copy hash code
+            m_hashCode = other.m_hashCode;
+
+            // Copy original string
+            m_originalString = other.m_originalString;
+
             return *this;
         }
 
@@ -285,11 +368,21 @@ namespace Hatchit {
          */
         Guid& Guid::operator=(Guid&& other)
         {
+            // Move GUID bytes
             for (int index = 0; index < 16; ++index)
             {
                 m_uuid[index] = other.m_uuid[index];
                 other.m_uuid[index] = 0;
             }
+
+            // Move hash code
+            m_hashCode = other.m_hashCode;
+            other.m_hashCode = 0;
+
+            // Move original string
+            m_originalString = other.m_originalString;
+            other.m_originalString = "";
+
             return *this;
         }
 


### PR DESCRIPTION
JSON extraction now includes float, int32, and uint32. It also still performs type checking in release mode, but without a branch and without printing anything to the debug log. You can add a define (which is commented out near the top of the JSON helper file) to explicitly disable type checking, but that is only available in release mode.

Also worth noting: the `JsonExtract*` macros are namespace-independent now. That means you do not need to prefix the calls with anything as they add `Hatchit::Core::` to the beginning of the extraction function.
