### PR TITLE
Fixed bug with Guid::Parse.

### DIFF
--- a/source/ht_guid.cpp
+++ b/source/ht_guid.cpp
@@ -280,6 +280,8 @@ namespace Hatchit {
                 }
             }
 
+            out.m_hashCode = GetFnv1aHash(out.m_uuid, 16);
+
             return true;
         }
 


### PR DESCRIPTION
Guid's did not have their m_hashCode attribute set in Guid::Parse. This
caused issues with reading Guids from JSON.
