### PR TITLE
Fixing a bug in _JsonExtractValue.

### DIFF
--- a/include/ht_jsonhelper.h
+++ b/include/ht_jsonhelper.h
@@ -52,15 +52,20 @@ namespace Hatchit {
         static inline bool _JsonExtractValue(const JSON& json, JsonVerifyFunc verify, const std::string& name, T& out)
         {
             auto  search = json.find(name);
-            auto& object = *search;
-
-            if (search == json.end() || !(object.*verify)())
+            if (search == json.end())
             {
-                HT_DEBUG_PRINTF("[JSON] Failed to extract '%s' from object as desired type.\n", name);
+                HT_DEBUG_PRINTF("[JSON] Failed to extract '%s' from object.\n", name);
                 return false;
             }
 
-            out = search->get<T>();
+            const JSON& obj = *search;
+            if (!(obj.*verify)())
+            {
+                HT_DEBUG_PRINTF("[JSON] Failed to verify type of '%s' extracted from object.\n", name);
+                return false;
+            }
+
+            out = obj.get<T>();
             return true;
         }
 


### PR DESCRIPTION
In _JsonExtractValue we invoked find, and then immediately dereferenced
the iterator before performing a comparison with cend() to check for a
valid iterator. This resulted in a crash if the JSON object could not be located. I separated this into two steps, first we check the iterator and then we invoke verify on the now validated JSON
object.
