### PR TITLE
Add base for more robust debugging system

### DIFF
--- a/include/ht_debug.h
+++ b/include/ht_debug.h
@@ -1,81 +1,114 @@
 /**
-**    Hatchit Engine
-**    Copyright(c) 2015 Third-Degree
-**
-**    GNU Lesser General Public License
-**    This file may be used under the terms of the GNU Lesser
-**    General Public License version 3 as published by the Free
-**    Software Foundation and appearing in the file LICENSE.LGPLv3 included
-**    in the packaging of this file. Please review the following information
-**    to ensure the GNU Lesser General Public License requirements
-**    will be met: https://www.gnu.org/licenses/lgpl.html
-**
-**/
+ **    Hatchit Engine
+ **    Copyright(c) 2015 Third-Degree
+ **
+ **    GNU Lesser General Public License
+ **    This file may be used under the terms of the GNU Lesser
+ **    General Public License version 3 as published by the Free
+ **    Software Foundation and appearing in the file LICENSE.LGPLv3 included
+ **    in the packaging of this file. Please review the following information
+ **    to ensure the GNU Lesser General Public License requirements
+ **    will be met: https://www.gnu.org/licenses/lgpl.html
+ **
+ **/
 
 #pragma once
 
-//Header includes
 #include <string>
-
-//Inline includes
+#include <fstream>
 #include <ht_platform.h>
-#include <iostream>
-#if defined(HT_SYS_WINDOWS)
-#include <debugapi.h>
-#endif
 #include <format.h>
 
+
 #ifndef HT_STRINGIFY
-#define HT_STRINGIFY(x) #x
+#  define HT_STRINGIFY(x) #x
 #endif
 
 #ifndef HT_SFY_
-#define HT_SFY_(x) HT_STRINGIFY(x)
+#  define HT_SFY_(x) HT_STRINGIFY(x)
 #endif
 
-#ifndef HT_SFY_FUNC
-#define HT_SFY_FUNC HT_SFY_(__FUNCTION__)
-#endif
-
-#ifndef HT_SFY_LINE
-#define HT_SFY_LINE HT_SFY_(__LINE__)
-#endif
-#ifndef HT_SFY_FILE
-#define HT_SFY_FILE HT_SFY_(__FILE__)
-#endif
-
-#ifndef HT_LOG_FILE
-#define HT_LOG_FILE "FILE: " HT_SFY_FILE
-#endif
-#ifndef HT_LOG_LINE
-#define HT_LOG_LINE "LINE: " HT_SFY_LINE
-#endif
-
-#ifndef HT_LOG_FUNC
-#define HT_LOG_FUNC "FUNC: " __FUNCTION__
-#endif
-
-#ifndef HT_LOG_PREFIX
-#define HT_LOG_PREFIX HT_LOG_FILE "\n" HT_LOG_FUNC "\n" HT_LOG_LINE "\n"
+#ifndef HT_INFO_PRINTF
+#  define HT_INFO_PRINTF(message, ...) Hatchit::Core::Debug::Log(Hatchit::Core::Debug::LogSeverity::Info, message, __VA_ARGS__)
 #endif
 
 #ifndef HT_DEBUG_PRINTF
-    #if defined(DEBUG) || defined(_DEBUG)
-        #define HT_DEBUG_PRINTF(fmt_string, ...) Hatchit::Core::DebugPrintF(fmt_string, ## __VA_ARGS__);
-    #else
-        #define HT_DEBUG_PRINTF(fmt_string, ...)
-    #endif
+#  define HT_DEBUG_PRINTF(message, ...) Hatchit::Core::Debug::Log(Hatchit::Core::Debug::LogSeverity::Debug, message, __VA_ARGS__)
+#endif
+
+#ifndef HT_WARNING_PRINTF
+#  define HT_WARNING_PRINTF(message, ...) Hatchit::Core::Debug::Log(Hatchit::Core::Debug::LogSeverity::Warning, message, __VA_ARGS__)
+#endif
+
+#ifndef HT_ERROR_PRINTF
+#  define HT_ERROR_PRINTF(message, ...) Hatchit::Core::Debug::Log(Hatchit::Core::Debug::LogSeverity::Error, message, __VA_ARGS__)
 #endif
 
 namespace Hatchit {
 
     namespace Core {
 
-        template<class ... Args> 
-        std::string DebugSprintF(const char* format, const Args& ... args);
+        /**
+         * \brief Defines a static debug class.
+         */
+        class HT_API Debug
+        {
+        public:
+            /**
+             * \brief An enumeration of log severities.
+             */
+            enum class LogSeverity
+            {
+                Debug,
+                Info,
+                Warning,
+                Error
+            };
 
-        template<class ... Args> 
-        size_t DebugPrintF(const char* format, const Args& ... args);
+            /**
+             * \brief Gets the current severity threshold.
+             *
+             * If a message is logged with a severity lower than the current severity
+             * threshold, then it will not be output for end-users to see.
+             */
+            static Debug::LogSeverity GetSeverityThreshold();
+            
+            /**
+             * \brief Logs a message with the given severity.
+             *
+             * \brief severity The message's severity.
+             * \brief fmt_message The message that is to be formatted.
+             * \brief args The arguments to format the message with.
+             */
+            template<class ... Args>
+            static void Log(Debug::LogSeverity severity, const std::string& fmt_message, const Args& ... args);
+
+            /**
+             * \brief Sets the current severity threshold.
+             *
+             * \param threshold The new severity threshold.
+             */
+            static void SetSeverityThreshold(LogSeverity threshold);
+
+        private:
+            /**
+             * \brief Logs the given message.
+             *
+             * \param message The message to log.
+             */
+            static void LogMessage(const std::string& message);
+
+            /**
+             * \brief Checks the given severity level and determines whether
+             *        or not a message should be logged.
+             *
+             * \param severity The severity level of the message to log.
+             */
+            static bool ShouldLogSeverity(Debug::LogSeverity severity);
+
+            static Debug::LogSeverity m_severityThreshold;
+        };
+
     }
 }
 

--- a/source/ht_debug.cpp
+++ b/source/ht_debug.cpp
@@ -1,18 +1,65 @@
-#include <ht_debug.h>
-#include <iostream>
+#include <ht_debug.h>       // For Debug::*
+#include <iostream>         // For std::cout
+#include <ctime>            // For std::time, std::localtime
 #if defined(HT_SYS_WINDOWS)
-#  include <debugapi.h>
+    #include <debugapi.h>   // For OutputDebugMessageA
 #endif
 
 namespace Hatchit {
 
     namespace Core {
 
+        std::string                     Debug::s_outputFile = "debug.log";
+        Debug::LogCallback              Debug::s_logCallback;
+        std::unique_ptr<std::ofstream>  Debug::s_outputStream;
+        bool                            Debug::s_canLogToFile = false;
+        const std::string               Debug::s_severityStrings[4] =
+        {
+            std::string("[DEBUG]"),
+            std::string("[INFO] "),
+            std::string("[WARN] "),
+            std::string("[ERROR]"),
+        };
 #if defined(_DEBUG) || defined(DEBUG)
-        Debug::LogSeverity Debug::m_severityThreshold = Debug::LogSeverity::Debug;
+        Debug::LogSeverity              Debug::s_severityThreshold = Debug::LogSeverity::Debug;
 #else
-        Debug::LogSeverity Debug::m_severityThreshold = Debug::LogSeverity::Info;
+        Debug::LogSeverity              Debug::s_severityThreshold = Debug::LogSeverity::Info;
 #endif
+
+        /**
+         * \brief Creates a full log message, including severity and a timestamp.
+         *
+         * \param severity The message severity.
+         * \param message The formatted user message.
+         * \return The full log message.
+         */
+        std::string Debug::CreateLogMessage(Debug::LogSeverity severity, std::string message)
+        {
+            return fmt::sprintf("%s %s %s", GenerateTimestamp(), s_severityStrings[static_cast<int>(severity)], message);
+        }
+
+        /**
+         * \brief Generates a timestamp.
+         *
+         * \return The timestamp.
+         */
+        std::string Debug::GenerateTimestamp()
+        {
+            std::time_t time_epoch = std::time(nullptr);
+            tm*         time_local = std::localtime(&time_epoch);
+
+            return fmt::sprintf("[%02d:%02d:%02d]", time_local->tm_hour, time_local->tm_min, time_local->tm_sec);
+        }
+
+        /**
+         * \brief Gets the file name of the output file.
+         *
+         * \return The output file name.
+         */
+        std::string Debug::GetOutputFileName()
+        {
+            return s_outputFile;
+        }
 
         /**
          * \brief Gets the current severity threshold.
@@ -22,21 +69,113 @@ namespace Hatchit {
          */
         Debug::LogSeverity Debug::GetSeverityThreshold()
         {
-            return m_severityThreshold;
+            return s_severityThreshold;
+        }
+
+        /**
+         * \brief Initializes the output stream.
+         */
+        void Debug::InitializeOutputStream()
+        {
+            bool canLog = true;
+
+            // Create the stream
+            if (!s_outputStream)
+            {
+                s_outputStream = std::make_unique<std::ofstream>();
+                if (!s_outputStream)
+                {
+                    LogMessage(CreateLogMessage(LogSeverity::Error, "Failed to allocate output file stream.\n"), false);
+                    canLog = false;
+                }
+            }
+
+            // Open the file
+            if (s_outputStream)
+            {
+                s_outputStream->open(s_outputFile, std::ios::app | std::ios::binary);
+                if (!s_outputStream->is_open())
+                {
+                    // We need to use LogMessage instead of Log here so that we don't try to open the file again
+                    LogMessage(CreateLogMessage(LogSeverity::Error, "Failed to open output file '" + s_outputFile + "'.\n"), false);
+                    canLog = false;
+                }
+            }
+
+            s_canLogToFile = canLog;
+
+            // If we can log to the file, add some kind of separator
+            if (canLog)
+            {
+                std::time_t time_epoch = std::time(nullptr);
+                tm*         time_local = std::localtime(&time_epoch);
+                std::string separator = fmt::sprintf(
+                    "------- LOG FILE OPENED ON %02d/%02d/%d -------\n",
+                    time_local->tm_mon + 1,
+                    time_local->tm_mday,
+                    time_local->tm_year + 1900);
+                LogMessage(CreateLogMessage(LogSeverity::Info, separator), false);
+            }
         }
 
         /**
          * \brief Logs the given message.
          *
-         * \param message The message to log.
+         * \param message The formatted message.
+         * \param tryOpenFile True to try to open the output file, false to not.
          */
-        void Debug::LogMessage(const std::string& message)
+        void Debug::LogMessage(const std::string& message, bool tryOpenFile)
         {
+            // If we should try to open the file then, well, try to open it
+            if (tryOpenFile && !s_canLogToFile)
+            {
+                InitializeOutputStream();
+            }
+
 #if defined(HT_SYS_WINDOWS)
+            // Output to the Visual Studio debug window
             OutputDebugStringA(message.c_str());
 #endif
 
-            std::cerr << message.c_str();
+            // Output to the console and file
+            std::cout << message.c_str();
+            if (s_canLogToFile)
+            {
+                (*s_outputStream) << message.c_str();
+            }
+
+            // Invoke the callback
+            if (s_logCallback)
+            {
+                s_logCallback(message);
+            }
+        }
+
+        /**
+         * \brief Sets the callback for whenever a message is logged.
+         *
+         * \param callback The new callback.
+         */
+        void Debug::SetLogCallback(LogCallback callback)
+        {
+            s_logCallback = callback;
+        }
+
+        /**
+         * \brief Sets the file name of the output file.
+         * \warning This function will not do anything after the first time something is logged.
+         *
+         * \param fname The new file name.
+         */
+        void Debug::SetOutputFileName(const std::string& fname)
+        {
+            if (s_outputStream && s_outputStream->is_open())
+            {
+                Log(LogSeverity::Error, "Cannot specify new file name after logging has begun.\n");
+                return;
+            }
+
+            s_outputFile = fname;
         }
 
         /**
@@ -46,7 +185,7 @@ namespace Hatchit {
          */
         void Debug::SetSeverityThreshold(Debug::LogSeverity threshold)
         {
-            m_severityThreshold = threshold;
+            s_severityThreshold = threshold;
         }
 
         /**
@@ -57,7 +196,7 @@ namespace Hatchit {
          */
         bool Debug::ShouldLogSeverity(Debug::LogSeverity severity)
         {
-            return static_cast<int>(severity) >= static_cast<int>(m_severityThreshold);
+            return static_cast<int>(severity) >= static_cast<int>(s_severityThreshold);
         }
 
     }

--- a/source/ht_debug.cpp
+++ b/source/ht_debug.cpp
@@ -1,0 +1,65 @@
+#include <ht_debug.h>
+#include <iostream>
+#if defined(HT_SYS_WINDOWS)
+#  include <debugapi.h>
+#endif
+
+namespace Hatchit {
+
+    namespace Core {
+
+#if defined(_DEBUG) || defined(DEBUG)
+        Debug::LogSeverity Debug::m_severityThreshold = Debug::LogSeverity::Debug;
+#else
+        Debug::LogSeverity Debug::m_severityThreshold = Debug::LogSeverity::Info;
+#endif
+
+        /**
+         * \brief Gets the current severity threshold.
+         *
+         * If a message is logged with a severity lower than the current severity
+         * threshold, then it will not be output for end-users to see.
+         */
+        Debug::LogSeverity Debug::GetSeverityThreshold()
+        {
+            return m_severityThreshold;
+        }
+
+        /**
+         * \brief Logs the given message.
+         *
+         * \param message The message to log.
+         */
+        void Debug::LogMessage(const std::string& message)
+        {
+#if defined(HT_SYS_WINDOWS)
+            OutputDebugStringA(message.c_str());
+#endif
+
+            std::cerr << message.c_str();
+        }
+
+        /**
+         * \brief Sets the current severity threshold.
+         *
+         * \param threshold The new severity threshold.
+         */
+        void Debug::SetSeverityThreshold(Debug::LogSeverity threshold)
+        {
+            m_severityThreshold = threshold;
+        }
+
+        /**
+         * \brief Checks the given severity level and determines whether
+         *        or not a message should be logged.
+         *
+         * \param severity The severity level of the message to log.
+         */
+        bool Debug::ShouldLogSeverity(Debug::LogSeverity severity)
+        {
+            return static_cast<int>(severity) >= static_cast<int>(m_severityThreshold);
+        }
+
+    }
+
+}

--- a/source/ht_inireader.cpp
+++ b/source/ht_inireader.cpp
@@ -32,10 +32,10 @@ namespace Hatchit {
 
 #ifdef _DEBUG
             /*Print loaded values to output window*/
-            DebugPrintF("[%s]:\n", file->Name().c_str());
+            HT_DEBUG_PRINTF("[%s]:\n", file->Name().c_str());
             for (auto val : m_values)
             {
-                DebugPrintF("%s : %s\n", val.first.c_str(), val.second.c_str());
+                HT_DEBUG_PRINTF("%s : %s\n", val.first.c_str(), val.second.c_str());
             }
 #endif
         }

--- a/source/inline/ht_debug.inl
+++ b/source/inline/ht_debug.inl
@@ -2,48 +2,35 @@
 
 #include <ht_debug.h>
 
-namespace Hatchit
-{
-    namespace Core
-    {
-        /*! \fn std::string DebugSprintF(const char* format, const Args& ... args) 
-        * \brief Function takes a formatted string and arguments to format into a string.
-        *
-        *
-        *  This debug utility function takes in a user format string and
-        *  a variable argument list, then prints the formatted string result
-        *  to the console.
-        *  @param format The format string.
-        *  @param args The argument list used with format string.
-        */
+namespace Hatchit {
+
+    namespace Core {
+
+        /**
+         * \brief Logs a message with the given severity.
+         *
+         * \brief severity The message's severity.
+         * \brief fmt_message The message that is to be formatted.
+         * \brief args The arguments to format the message with.
+         */
         template<class ... Args>
-        inline std::string DebugSprintF(const char* format, const Args& ... args)
+        void Debug::Log(Debug::LogSeverity severity, const std::string& fmt_message, const Args& ... args)
         {
-            return fmt::sprintf(format, args ...);
+            static const std::string s_messagePrefixes[4] =
+            {
+                std::string("[DEBUG] "),
+                std::string("[INFO]  "),
+                std::string("[WARN]  "),
+                std::string("[ERROR] "),
+            };
+
+            if (ShouldLogSeverity(severity))
+            {
+                std::string message = fmt::sprintf(fmt_message, args ...);
+                std::string prefix = s_messagePrefixes[static_cast<int>(severity)];
+                LogMessage(prefix + message);
+            }
         }
 
-        /*! \fn size_t DebugPrintF(const char* format, const Args& ... args) 
-        * \brief Function takes a formatted string and arguments to print.
-        *
-        *
-        *  This debug utility function takes in a user format string and
-        *  a variable argument list, then prints the formatted string result
-        *  to the console.
-        *  @param format The format string.
-        *  @param args The argument list used with format string.
-        */
-        template<class ... Args>
-        inline size_t DebugPrintF(const char* format, const Args& ... args)
-        {
-            std::string message = fmt::sprintf(format, args ...);
-
-#if defined(HT_SYS_WINDOWS)
-            OutputDebugStringA(message.c_str());
-#endif
-
-            std::cerr << message.c_str();
-
-            return message.length();
-        }
     }
 }

--- a/source/inline/ht_debug.inl
+++ b/source/inline/ht_debug.inl
@@ -16,20 +16,15 @@ namespace Hatchit {
         template<class ... Args>
         void Debug::Log(Debug::LogSeverity severity, const std::string& fmt_message, const Args& ... args)
         {
-            static const std::string s_messagePrefixes[4] =
+            if (!ShouldLogSeverity(severity))
             {
-                std::string("[DEBUG] "),
-                std::string("[INFO]  "),
-                std::string("[WARN]  "),
-                std::string("[ERROR] "),
-            };
-
-            if (ShouldLogSeverity(severity))
-            {
-                std::string message = fmt::sprintf(fmt_message, args ...);
-                std::string prefix = s_messagePrefixes[static_cast<int>(severity)];
-                LogMessage(prefix + message);
+                return;
             }
+
+            std::string message = fmt::sprintf(fmt_message, args ...);
+            message = Debug::CreateLogMessage(severity, message);
+
+            LogMessage(message, true);
         }
 
     }


### PR DESCRIPTION
This PR includes changes that will lay the foundations for a much more robust debugging system. The following features have been added:
- `Debug` class instead of raw `DebugPrintF` function
- Log severity levels
- Logging callbacks
- Logging to a file
- Timestamps for log messages
- Three more macros for printing messages besides with a severity other than `Debug`

However, this PR does introduce breaking changes in that some submodules directly used `DebugPrintF` instead of the macro `HT_DEBUG_PRINTF`. The following submodules do not compile for me with the changes in this PR:
- HatchitClient
- HatchitGame
- HatchitNetwork
- HatchitServer
- HatchitTest
