### PR TITLE
Use std::fstream instead of FILE* for File

### DIFF
--- a/include/ht_file.h
+++ b/include/ht_file.h
@@ -19,8 +19,6 @@
 #include <ht_file_interface.h> //IFile
 #include <string> //std::string typedef
 #include <cstddef> //size_t typedef
-#include <cstdio> //FILE typedef
-
 
 namespace Hatchit {
 
@@ -33,27 +31,28 @@ namespace Hatchit {
 
             ~File(void);
 
-            virtual std::string Name(void)                                      override;
-            virtual std::string Path(void)                                      override;
-            virtual std::string BaseName(void)                                  override;
-            virtual void        Open(const std::string& path, FileMode mode)    override;
-            virtual bool        Seek(long offset, FileSeek mode)                override;
-            virtual size_t      Read(BYTE* out, size_t len)                     override;
-            virtual size_t      Write(BYTE* in, size_t len)                     override;
-            virtual bool        Close(void)                                     override;
-            virtual size_t      Tell(void)                                      override;
-            virtual size_t      SizeBytes(void)                                 override;
-            virtual size_t      SizeKBytes(void)                                override;
-            virtual size_t      Position(void)                                  override;
-            virtual FILE*       Handle(void)                                    override;
-
+            virtual std::string     Name(void)                                      override;
+            virtual std::string     Path(void)                                      override;
+            virtual std::string     BaseName(void)                                  override;
+            virtual void            Open(const std::string& path, FileMode mode)    override;
+            virtual bool            Seek(long offset, FileSeek mode)                override;
+            virtual size_t          Read(BYTE* out, size_t len)                     override;
+            virtual size_t          Write(const BYTE* in, size_t len)               override;
+            virtual bool            Close(void)                                     override;
+            virtual size_t          Tell(void)                                      override;
+            virtual size_t          SizeBytes(void)                                 override;
+            virtual size_t          SizeKBytes(void)                                override;
+            virtual size_t          Position(void)                                  override;
+            virtual std::fstream*   Handle(void)                                    override;
+            
         private:
-            std::string m_path;
-            std::string m_name;
-            std::string m_baseName;
-            size_t      m_position;
-            size_t      m_size;
-            FILE*       m_handle;
+            std::fstream    m_handle;
+            std::string     m_path;
+            std::string     m_name;
+            std::string     m_baseName;
+            size_t          m_position;
+            size_t          m_size;
+            unsigned int    m_mode;
         };
 
     }

--- a/include/ht_file.h
+++ b/include/ht_file.h
@@ -17,6 +17,7 @@
 //Header includes
 #include <ht_platform.h> //HT_API
 #include <ht_file_interface.h> //IFile
+#include <fstream> //std::fstream typedef
 #include <string> //std::string typedef
 #include <cstddef> //size_t typedef
 

--- a/include/ht_file_interface.h
+++ b/include/ht_file_interface.h
@@ -16,8 +16,8 @@
 
 #include <ht_platform.h> //HT_API
 #include <string> //std::string typedef
+#include <fstream> //std::fstream typedef
 #include <cstddef> //size_t typedef
-#include <cstdio> //FILE typedef
 #include <ht_noncopy.h> //INonCopy
 
 namespace Hatchit {
@@ -91,7 +91,7 @@ namespace Hatchit {
 
             Returns the name of the file, i.e. FileName.txt
             **/
-            virtual std::string Name(void) = 0;
+            virtual std::string     Name(void) = 0;
 
             /**
             \fn std::string IFile::Path()
@@ -100,7 +100,7 @@ namespace Hatchit {
             Returns the relative path to the file.
             Path includes file name appended to end.
             **/
-            virtual std::string Path(void) = 0;
+            virtual std::string     Path(void) = 0;
 
             /**
             \fn std::string IFile::BaseName()
@@ -109,7 +109,7 @@ namespace Hatchit {
             Returns the base name of the system file open.  Base
             name is the name of the file without the extension.
             **/
-            virtual std::string BaseName(void) = 0;
+            virtual std::string     BaseName(void) = 0;
 
             /**
             \fn void IFile::Open(const std::string& path, FileMode mode)
@@ -118,7 +118,7 @@ namespace Hatchit {
             Opens the file at the given relative path.  Then populates member data
             with information about the open file.
             **/
-            virtual void        Open(const std::string& path, FileMode mode) = 0;
+            virtual void            Open(const std::string& path, FileMode mode) = 0;
 
             /**
             \fn bool IFile::Seek(long offset, FileSeek mode)
@@ -129,7 +129,7 @@ namespace Hatchit {
             relative to the given FileSeek enum.
             \return Whether seeked position was found and moved to.
             **/
-            virtual bool        Seek(long offset, FileSeek mode) = 0;
+            virtual bool            Seek(long offset, FileSeek mode) = 0;
 
             /**
             \fn bool IFile::Close()
@@ -140,7 +140,7 @@ namespace Hatchit {
             of File objects.
             \return Whether file was successfully closed or not.
             **/
-            virtual bool        Close(void) = 0;
+            virtual bool            Close(void) = 0;
 
             /**
             \fn size_t IFile::Read(BYTE* out, size_t length)
@@ -151,7 +151,7 @@ namespace Hatchit {
             \a length number of bytes
             \return Number of bytes read into byte array.
             **/
-            virtual size_t      Read(BYTE* out, size_t len) = 0;
+            virtual size_t          Read(BYTE* out, size_t len) = 0;
 
             /**
             \fn size_t IFile::Write(BYTE* in, size_t len)
@@ -162,7 +162,7 @@ namespace Hatchit {
             \a len bytes.
             \return Number of bytes written to file.
             **/
-            virtual size_t      Write(BYTE* in, size_t len) = 0;
+            virtual size_t          Write(const BYTE* in, size_t len) = 0;
 
             /**
             \fn size_t IFile::Tell()
@@ -175,7 +175,7 @@ namespace Hatchit {
             but can still be used to return to the same location with 
             IFile::Seek(long offset, FileSeek mode);
             **/
-            virtual size_t      Tell(void) = 0;
+            virtual size_t          Tell(void) = 0;
 
             /**
             \fn size_t IFile::SizeBytes()
@@ -183,7 +183,7 @@ namespace Hatchit {
 
             Gives size of file in bytes.
             **/
-            virtual size_t      SizeBytes(void) = 0;
+            virtual size_t          SizeBytes(void) = 0;
 
             /**
             \fn size_t IFile::SizeKBytes()
@@ -191,7 +191,7 @@ namespace Hatchit {
 
             Gives size of file in kilobytes
             **/
-            virtual size_t      SizeKBytes(void) = 0;
+            virtual size_t          SizeKBytes(void) = 0;
 
             /**
             \fn size_t IFile::Position()
@@ -200,7 +200,7 @@ namespace Hatchit {
             Returns position of stream pointer in file (relative to beginning
             of file).
             **/
-            virtual size_t      Position(void) = 0;
+            virtual size_t          Position(void) = 0;
 
             /**
             \fn FILE* IFile::Handle()
@@ -208,7 +208,7 @@ namespace Hatchit {
 
             Gives file pointer to opened file.
             **/
-            virtual FILE*       Handle() = 0;
+            virtual std::fstream*   Handle() = 0;
         };
 
     }

--- a/include/ht_inireader.h
+++ b/include/ht_inireader.h
@@ -43,6 +43,7 @@ namespace Hatchit {
 
             std::string Get(std::string section, std::string name);
             static std::string      MakeKey(std::string section, std::string name);
+            static char*            StreamReader(char* str, int len, void* stream);
             static int              ValueHandler(void* user, const char* section, const char* name, const char* value);
         };
 

--- a/source/ht_file.cpp
+++ b/source/ht_file.cpp
@@ -107,6 +107,7 @@ namespace Hatchit
             m_path = os_path(path);
             m_name = GetName(m_path);
             m_baseName = GetName(m_path, false);
+            m_position = 0;
             m_mode = 0;
 
             switch (mode)
@@ -184,11 +185,12 @@ namespace Hatchit
             m_handle.read(reinterpret_cast<char*>(out), len);
             size_t count = m_handle.gcount();
 
-            if (count == 0)
-            {
-                throw FileException(m_path, errno);
-            }
+            //if (count == 0)
+            //{
+            //    throw FileException(m_path, errno);
+            //}
 
+            m_position += count;
             return count;
         }
 
@@ -211,6 +213,7 @@ namespace Hatchit
                 throw FileException(m_path, errno);
             }
 
+            m_position += len;
             return len;
         }
 
@@ -299,7 +302,7 @@ namespace Hatchit
         **/
         size_t File::Position(void)
         {
-            return Tell();
+            return m_position;
         }
 
         /**

--- a/source/ht_file.cpp
+++ b/source/ht_file.cpp
@@ -177,18 +177,17 @@ namespace Hatchit
         Reads the contents of the file and places into buffer \a out.  Length
         of the buffer must be provided by \a len.
 
-        /exception FileException The end of the file has already been reached, or
-        if length given is 0.
+        /exception FileException The end of the file has already been reached.
         **/
         size_t File::Read(BYTE* out, size_t len)
         {
+            if (m_handle.eof())
+            {
+                throw FileException(m_path, EIO);
+            }
+
             m_handle.read(reinterpret_cast<char*>(out), len);
             size_t count = m_handle.gcount();
-
-            //if (count == 0)
-            //{
-            //    throw FileException(m_path, errno);
-            //}
 
             m_position += count;
             return count;

--- a/source/ht_inireader.cpp
+++ b/source/ht_inireader.cpp
@@ -26,7 +26,7 @@ namespace Hatchit {
 
         void INIReader::Load(File* file)
         {
-            int error = ini_parse_file(file->Handle(), ValueHandler, this);
+            int error = ini_parse_stream(StreamReader, file, ValueHandler, this);
             if (error != 0)
                 throw INIException(file->Name(), error);
 
@@ -60,6 +60,16 @@ namespace Hatchit {
             std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 
             return key;
+        }
+
+        char* INIReader::StreamReader(char* str, int len, void* stream)
+        {
+            File* file = static_cast<File*>(stream);
+            size_t count = file->Read(reinterpret_cast<BYTE*>(str), len);
+
+            if (count)
+                return str;
+            return nullptr;
         }
 
         int INIReader::ValueHandler(void* user, const char* section, const char* name, const char* value)


### PR DESCRIPTION
This PR removes the usage of C-style file reading/writing and implements it instead with an `std::fstream`.

It is worth mentioning that the Image class in Resource will need to be updated to use `stbi_load_from_callbacks` as it previously used the `FILE*` for `stbi_load_from_file`. Here is a quick implementation that I wrote to make my local copy of the engine compile (changes are in `ht_image.cpp`):

``` c++
static int FileEOFCallback(void* file)
{
    return static_cast<Core::File*>(file)->Handle()->eof();
}

static int FileReadCallback(void* file, char* data, int size)
{
    return static_cast<Core::File*>(file)->Read(reinterpret_cast<BYTE*>(data), size);
}

static void FileSkipCallback(void* file, int n)
{
    static_cast<Core::File*>(file)->Seek(n, Core::File::FileSeek::Current);
}

// ----------------------------------------------------
// Later on in Image::Load
// ----------------------------------------------------

stbi_io_callbacks callbacks;
callbacks.eof = FileEOFCallback;
callbacks.read = FileReadCallback;
callbacks.skip = FileSkipCallback;

bitmap->m_data = stbi_load_from_callbacks(&callbacks, file,
    &bitmap->m_width, &bitmap->m_height, &bitmap->m_channels,
    req_channels);
```
