### PR TITLE
Fix for thirddegree/HatchitGame#28.

### DIFF
--- a/source/inline/ht_jsonhelper.inl
+++ b/source/inline/ht_jsonhelper.inl
@@ -70,8 +70,12 @@ namespace Hatchit
                 return true;
 #   else
                 auto  search = json.find(name);
-                auto& object = *search;
+                if (search == json.end())
+                {
+                    return false;
+                }
 
+                auto& object = *search;
                 out = object.get<T>();
                 return (object.*verify)();
 #   endif


### PR DESCRIPTION
This should resolve the issue where the two raptors with
MeshRendererComponents were not being displayed in Release. We were not
verifying the iterator returned by nlohmann::json::find before accessing
the object it contained in Release. As a result of this, if the requested
JSON property did not exist an exception was thrown by nlohmann::json.
